### PR TITLE
Fixes status screen negative size and rewards all being in the same line.

### DIFF
--- a/habitica.el
+++ b/habitica.el
@@ -360,7 +360,7 @@ ORDER is the ordered list of ids to print the rewards in."
     (dolist (reward (append rewards nil))
       (if (equal (assoc-default 'id reward) id)
           (progn  (insert "** ")
-                  (insert (assoc-default 'text reward))
+                  (insert (concat (assoc-default 'text reward) " \n"))
                   (org-set-tags-to (format "%d" (assoc-default 'value reward)))
                   (org-set-property "ID" (assoc-default '_id reward)))))))
 

--- a/habitica.el
+++ b/habitica.el
@@ -463,6 +463,7 @@ PROFILE is the JSON formatted response."
 CURRENT is the current value
 MAX is the max value
 LENGTH is the total number of characters in the bar."
+  (if (< max current) (setq max current) nil)
   (concat "["
           (make-string (truncate (fround (* (/ current max) length))) ?#)
           (make-string (truncate (fround (* (/ (- max current) max) length))) ?-)


### PR DESCRIPTION
When in habitica status bar the current value is higher than the maximum the client computes a negative length for the status string resulting in screen not rendering correctly.
The situation is possible for the mana status in which then end of task or a spell can assign extra mana which may be removed at cron. It is hence a valid situation for a status in which the current is higher than the maximum.

The current fix resolves this situation. by just taking as max the highest of both values.
