### PR TITLE
Fix status bar format

### DIFF
--- a/habitica.el
+++ b/habitica.el
@@ -489,8 +489,8 @@ MAX is the max value
 LENGTH is the total number of characters in the bar."
   (if (< max current) (setq max current) nil)
   (concat "["
-          (make-string (truncate (round (* (/ current max) length))) ?#)
-          (make-string (truncate (round (* (/ (- max current) max) length))) ?-)
+          (make-string (truncate (round (* (/ (float current) max) length))) ?#)
+          (make-string (truncate (round (* (/ (float (- max current)) max) length))) ?-)
           "]"))
 
 (defun habitica--parse-profile (stats show-notification)


### PR DESCRIPTION
In its current form the status bar seems to be either empty or full, for example: 
```
** Health : []  16 / 50
** Exp    : []  1269 / 2160
** Mana   : [####################]  120 / 120
```

We need to convert at least one number to float in order to get the result of the division with decimals.